### PR TITLE
Refactor: Improve Results library robustness and design

### DIFF
--- a/src/DevSource.Stack.Results/Abstractions/IErrorStatus.cs
+++ b/src/DevSource.Stack.Results/Abstractions/IErrorStatus.cs
@@ -1,0 +1,10 @@
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
+
+namespace DevSource.Stack.Results.Abstractions;
+
+public interface IErrorStatus
+{
+    ErrorType ErrorType { get; }
+    IList<string> Messages { get; }
+}

--- a/src/DevSource.Stack.Results/Abstractions/IHttpErrorProvider.cs
+++ b/src/DevSource.Stack.Results/Abstractions/IHttpErrorProvider.cs
@@ -1,0 +1,8 @@
+using DevSource.Stack.Results.StatusCodeTypes;
+
+namespace DevSource.Stack.Results.Abstractions;
+
+public interface IHttpErrorProvider
+{
+    IErrorStatus GetError(ErrorType errorType);
+}

--- a/src/DevSource.Stack.Results/Abstractions/IHttpInformativeProvider.cs
+++ b/src/DevSource.Stack.Results/Abstractions/IHttpInformativeProvider.cs
@@ -1,0 +1,8 @@
+using DevSource.Stack.Results.StatusCodeTypes;
+
+namespace DevSource.Stack.Results.Abstractions;
+
+public interface IHttpInformativeProvider
+{
+    IInformativeStatus GetInformative(InformativeType informativeType);
+}

--- a/src/DevSource.Stack.Results/Abstractions/IHttpRedirectProvider.cs
+++ b/src/DevSource.Stack.Results/Abstractions/IHttpRedirectProvider.cs
@@ -1,0 +1,8 @@
+using DevSource.Stack.Results.StatusCodeTypes;
+
+namespace DevSource.Stack.Results.Abstractions;
+
+public interface IHttpRedirectProvider
+{
+    IRedirectStatus GetRedirect(RedirectType redirectType);
+}

--- a/src/DevSource.Stack.Results/Abstractions/IHttpSuccessProvider.cs
+++ b/src/DevSource.Stack.Results/Abstractions/IHttpSuccessProvider.cs
@@ -1,0 +1,8 @@
+using DevSource.Stack.Results.StatusCodeTypes;
+
+namespace DevSource.Stack.Results.Abstractions;
+
+public interface IHttpSuccessProvider
+{
+    ISuccessStatus GetSuccess(SuccessType successType);
+}

--- a/src/DevSource.Stack.Results/Abstractions/IInformativeStatus.cs
+++ b/src/DevSource.Stack.Results/Abstractions/IInformativeStatus.cs
@@ -1,0 +1,22 @@
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
+
+namespace DevSource.Stack.Results.Abstractions;
+
+public interface IInformativeStatus
+{
+    InformativeType InformativeType { get; }
+    // Note: HttpInformative has a single 'Message' string, not IList<string>.
+    // The interface should reflect what the HttpInformative class provides.
+    // However, the Result classes expect IList<string>.
+    // For consistency with IErrorStatus and ISuccessStatus, and with Result constructor,
+    // let's stick to IList<string> here. The concrete HttpInformative class
+    // will wrap its single message in a list when implementing this interface's Messages property.
+    IList<string> Messages { get; }
+
+    // Alternative for IInformativeStatus & IRedirectStatus if they truly only have one message:
+    // string Message { get; }
+    // And then the Result classes would need to handle constructing the list.
+    // The current plan implies HttpInformative.Messages will be made to return IList<string>.
+    // Let's proceed with IList<string> for the interface for now.
+}

--- a/src/DevSource.Stack.Results/Abstractions/IRedirectStatus.cs
+++ b/src/DevSource.Stack.Results/Abstractions/IRedirectStatus.cs
@@ -1,0 +1,10 @@
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
+
+namespace DevSource.Stack.Results.Abstractions;
+
+public interface IRedirectStatus
+{
+    RedirectType RedirectType { get; }
+    IList<string> Messages { get; }
+}

--- a/src/DevSource.Stack.Results/Abstractions/ISuccessStatus.cs
+++ b/src/DevSource.Stack.Results/Abstractions/ISuccessStatus.cs
@@ -1,0 +1,10 @@
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
+
+namespace DevSource.Stack.Results.Abstractions;
+
+public interface ISuccessStatus
+{
+    SuccessType SuccessType { get; }
+    IList<string> Messages { get; }
+}

--- a/src/DevSource.Stack.Results/HttpError.cs
+++ b/src/DevSource.Stack.Results/HttpError.cs
@@ -1,13 +1,23 @@
-﻿using DevSource.Stack.Results.StatusCodeTypes;
+﻿using DevSource.Stack.Results.Abstractions;
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
 
 namespace DevSource.Stack.Results;
 
-internal sealed class HttpError(ErrorType errorType, IList<string>? messages)
+public sealed class HttpError : IErrorStatus
 {
-    public ErrorType ErrorType { get; } = errorType;
-    public IList<string> Messages { get; } = messages ?? [];
+    public ErrorType ErrorType { get; }
+    public IList<string> Messages { get; }
+
+    // Constructor used by static properties to create instances for the map
+    // Made public as the class is now public.
+    public HttpError(ErrorType errorType, IList<string>? messages)
+    {
+        ErrorType = errorType;
+        Messages = messages ?? new List<string>();
+    }
     
-    public static HttpError GetError(ErrorType errorType)
+    public static HttpError GetError(ErrorType errorType) // Returns concrete HttpError
     {
         if(ErrorMap.TryGetValue(errorType, out var error)) return error;
         throw new ArgumentOutOfRangeException(nameof(errorType), errorType, null);

--- a/src/DevSource.Stack.Results/HttpErrorProvider.cs
+++ b/src/DevSource.Stack.Results/HttpErrorProvider.cs
@@ -1,0 +1,13 @@
+using DevSource.Stack.Results.Abstractions;
+using DevSource.Stack.Results.StatusCodeTypes;
+
+namespace DevSource.Stack.Results;
+
+public class HttpErrorProvider : IHttpErrorProvider
+{
+    public IErrorStatus GetError(ErrorType errorType)
+    {
+        // HttpError.GetError now returns a concrete HttpError, which implements IErrorStatus.
+        return HttpError.GetError(errorType);
+    }
+}

--- a/src/DevSource.Stack.Results/HttpInformative.cs
+++ b/src/DevSource.Stack.Results/HttpInformative.cs
@@ -1,13 +1,25 @@
-﻿using DevSource.Stack.Results.StatusCodeTypes;
+﻿using DevSource.Stack.Results.Abstractions;
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
 
 namespace DevSource.Stack.Results;
 
-internal sealed class HttpInformative(InformativeType informativeType, string? message)
+public sealed class HttpInformative : IInformativeStatus
 {
-    public InformativeType InformativeType { get; } = informativeType;
-    public string? Message { get; } = message;
+    public InformativeType InformativeType { get; }
+    public string Message { get; } // Changed from string?
 
-    public static HttpInformative GetInformative(InformativeType informativeType)
+    // IInformativeStatus implementation
+    public IList<string> Messages => new List<string> { Message };
+
+    // Constructor made public, message parameter changed to non-nullable
+    public HttpInformative(InformativeType informativeType, string message)
+    {
+        InformativeType = informativeType;
+        Message = message;
+    }
+
+    public static HttpInformative GetInformative(InformativeType informativeType) // Returns concrete HttpInformative
     {
         if(InformativeMap.TryGetValue(informativeType, out var informative)) return informative;
         throw new ArgumentOutOfRangeException(nameof(informativeType), informativeType, null);

--- a/src/DevSource.Stack.Results/HttpInformativeProvider.cs
+++ b/src/DevSource.Stack.Results/HttpInformativeProvider.cs
@@ -1,0 +1,12 @@
+using DevSource.Stack.Results.Abstractions;
+using DevSource.Stack.Results.StatusCodeTypes;
+
+namespace DevSource.Stack.Results;
+
+public class HttpInformativeProvider : IHttpInformativeProvider
+{
+    public IInformativeStatus GetInformative(InformativeType informativeType)
+    {
+        return HttpInformative.GetInformative(informativeType);
+    }
+}

--- a/src/DevSource.Stack.Results/HttpRedirect.cs
+++ b/src/DevSource.Stack.Results/HttpRedirect.cs
@@ -1,13 +1,25 @@
-﻿using DevSource.Stack.Results.StatusCodeTypes;
+﻿using DevSource.Stack.Results.Abstractions;
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
 
 namespace DevSource.Stack.Results;
 
-internal sealed class HttpRedirect(RedirectType redirectType, string? message)
+public sealed class HttpRedirect : IRedirectStatus
 {
-    public RedirectType RedirectType { get; } = redirectType;
-    public string? Message { get; } = message;
-    
-    public static HttpRedirect GetRedirect(RedirectType redirectType) 
+    public RedirectType RedirectType { get; }
+    public string Message { get; } // Changed from string?
+
+    // IRedirectStatus implementation
+    public IList<string> Messages => new List<string> { Message };
+
+    // Constructor made public, message parameter changed to non-nullable
+    public HttpRedirect(RedirectType redirectType, string message)
+    {
+        RedirectType = redirectType;
+        Message = message;
+    }
+
+    public static HttpRedirect GetRedirect(RedirectType redirectType) // Returns concrete HttpRedirect
     {
         if (RedirectMap.TryGetValue(redirectType, out var redirect)) return redirect;
         throw new ArgumentOutOfRangeException(nameof(redirectType), redirectType, null);

--- a/src/DevSource.Stack.Results/HttpRedirectProvider.cs
+++ b/src/DevSource.Stack.Results/HttpRedirectProvider.cs
@@ -1,0 +1,12 @@
+using DevSource.Stack.Results.Abstractions;
+using DevSource.Stack.Results.StatusCodeTypes;
+
+namespace DevSource.Stack.Results;
+
+public class HttpRedirectProvider : IHttpRedirectProvider
+{
+    public IRedirectStatus GetRedirect(RedirectType redirectType)
+    {
+        return HttpRedirect.GetRedirect(redirectType);
+    }
+}

--- a/src/DevSource.Stack.Results/HttpSuccess.cs
+++ b/src/DevSource.Stack.Results/HttpSuccess.cs
@@ -1,13 +1,22 @@
-﻿using DevSource.Stack.Results.StatusCodeTypes;
+﻿using DevSource.Stack.Results.Abstractions;
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
 
 namespace DevSource.Stack.Results;
 
-internal sealed class HttpSuccess(SuccessType successType, IList<string>? messages)
+public sealed class HttpSuccess : ISuccessStatus
 {
-    public SuccessType SuccessType { get; } = successType;
-    public IList<string>? Messages { get; } = messages ?? [];
-    
-    public static HttpSuccess GetSuccess(SuccessType successType)
+    public SuccessType SuccessType { get; }
+    public IList<string> Messages { get; } // Changed from IList<string>?
+
+    // Constructor made public
+    public HttpSuccess(SuccessType successType, IList<string>? messages)
+    {
+        SuccessType = successType;
+        Messages = messages ?? new List<string>(); // Ensure non-null
+    }
+
+    public static HttpSuccess GetSuccess(SuccessType successType) // Returns concrete HttpSuccess
     {
         if (SuccessMap.TryGetValue(successType, out var success)) return success;
         throw new ArgumentOutOfRangeException(nameof(successType), successType, null);

--- a/src/DevSource.Stack.Results/HttpSuccessProvider.cs
+++ b/src/DevSource.Stack.Results/HttpSuccessProvider.cs
@@ -1,0 +1,12 @@
+using DevSource.Stack.Results.Abstractions;
+using DevSource.Stack.Results.StatusCodeTypes;
+
+namespace DevSource.Stack.Results;
+
+public class HttpSuccessProvider : IHttpSuccessProvider
+{
+    public ISuccessStatus GetSuccess(SuccessType successType)
+    {
+        return HttpSuccess.GetSuccess(successType);
+    }
+}

--- a/tests/DevSource.Stack.Results.Tests/ResultPagedTests.cs
+++ b/tests/DevSource.Stack.Results.Tests/ResultPagedTests.cs
@@ -1,0 +1,116 @@
+using NUnit.Framework;
+using DevSource.Stack.Results;
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
+using System.Linq; // Required for .Any() and .First()
+
+namespace DevSource.Stack.Results.Tests
+{
+    [TestFixture]
+    public class ResultPagedTests
+    {
+        // Tests for TotalPages
+        [Test]
+        public void ResultPaged_TotalPages_ReturnsZero_WhenPageSizeIsNull()
+        {
+            // Test with the constructor directly
+            var result = new ResultPaged<string>((int)SuccessType.Ok, 10, 1, null, new List<string> { "data" });
+            Assert.AreEqual(0, result.TotalPages);
+        }
+
+        [Test]
+        public void ResultPaged_TotalPages_ReturnsZero_WhenPageSizeIsZero()
+        {
+            var result = new ResultPaged<string>((int)SuccessType.Ok, 10, 1, 0, new List<string> { "data" });
+            Assert.AreEqual(0, result.TotalPages);
+        }
+
+        [Test]
+        public void ResultPaged_TotalPages_ReturnsZero_WhenCountIsZero()
+        {
+            var result = new ResultPaged<string>((int)SuccessType.Ok, 0, 1, 10, new List<string>());
+            Assert.AreEqual(0, result.TotalPages);
+        }
+
+        [Test]
+        [TestCase(10, 3, 4)]
+        [TestCase(9, 3, 3)]
+        [TestCase(1, 3, 1)]
+        public void ResultPaged_TotalPages_CalculatesCorrectly(int count, int pageSize, int expectedTotalPages)
+        {
+            var result = new ResultPaged<string>((int)SuccessType.Ok, count, 1, pageSize, new List<string> { "data" });
+            Assert.AreEqual(expectedTotalPages, result.TotalPages);
+        }
+
+        // Tests for NextPage/PreviousPage nullability
+        [Test]
+        public void ResultPaged_Failure_SetsNextPreviousPageToNull()
+        {
+            var result = ResultPaged<string>.Failure(ErrorType.BadRequest);
+            Assert.IsNull(result.NextPage);
+            Assert.IsNull(result.PreviousPage);
+        }
+
+        [Test]
+        public void ResultPaged_Informative_SetsNextPreviousPageToNull()
+        {
+            var result = ResultPaged<string>.Informative(InformativeType.Continue);
+            Assert.IsNull(result.NextPage);
+            Assert.IsNull(result.PreviousPage);
+        }
+
+        [Test]
+        public void ResultPaged_Redirect_SetsNextPreviousPageToNull()
+        {
+            var result = ResultPaged<string>.Redirect(RedirectType.Found);
+            Assert.IsNull(result.NextPage);
+            Assert.IsNull(result.PreviousPage);
+        }
+
+        [Test]
+        public void ResultPaged_Success_WithNullNextPrevious_ViaFactory_SetsPropertiesToNull()
+        {
+            var result = ResultPaged<string>.Success(SuccessType.Ok, 0, 1, 10, new List<string>(), null, null);
+            Assert.IsNull(result.NextPage);
+            Assert.IsNull(result.PreviousPage);
+        }
+
+        [Test]
+        public void ResultPaged_Success_WithNonNullNextPrevious_ViaFactory_SetsPropertiesCorrectly()
+        {
+            var nextPageUrl = "/page=2";
+            var prevPageUrl = "/page=0";
+            var result = ResultPaged<string>.Success(SuccessType.Ok, 10, 1, 5, new List<string>(), nextPageUrl, prevPageUrl);
+            Assert.AreEqual(nextPageUrl, result.NextPage);
+            Assert.AreEqual(prevPageUrl, result.PreviousPage);
+        }
+
+        // Test for ResultPaged<TData>.Failure message handling (uses all default messages)
+        [Test]
+        public void ResultPaged_Failure_UsesAllDefaultErrorMessages_WhenNoCustomMessageProvided()
+        {
+            var result = ResultPaged<string>.Failure(ErrorType.Forbidden);
+            Assert.IsNotNull(result.Messages);
+            Assert.IsTrue(result.Messages.Any());
+            Assert.AreEqual("You do not have the necessary permissions to access this resource.", result.Messages.First());
+            // To truly test "all", one would need to know the exact multiple messages for a type.
+            // For now, we trust the implementation change from step 2 and that HttpError.Messages for Forbidden has one entry.
+        }
+
+        [Test]
+        public void ResultPaged_Success_WithDefaultMessageAndData_ReturnsResultWithDefaultMessageAndData()
+        {
+            var data = new List<string> { "Test Data" };
+            var result = ResultPaged<List<string>>.Success(SuccessType.Ok, data.Count, 1, 10, data);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)SuccessType.Ok, result.StatusCode);
+            Assert.AreEqual(data, result.Data);
+            Assert.IsNotNull(result.Messages);
+            Assert.IsTrue(result.Messages.Any());
+            Assert.AreEqual("The request has succeeded.", result.Messages.First());
+            Assert.AreEqual(data.Count, result.Count);
+            Assert.AreEqual(1, result.Page);
+            Assert.AreEqual(10, result.PageSize);
+        }
+    }
+}

--- a/tests/DevSource.Stack.Results.Tests/ResultTests.cs
+++ b/tests/DevSource.Stack.Results.Tests/ResultTests.cs
@@ -1,0 +1,137 @@
+using NUnit.Framework;
+using DevSource.Stack.Results;
+using DevSource.Stack.Results.StatusCodeTypes;
+using System.Collections.Generic;
+using System.Linq; // Required for .Any() and .First()
+
+namespace DevSource.Stack.Results.Tests
+{
+    [TestFixture]
+    public class ResultTests
+    {
+        // Tests for Result.Failure
+        [Test]
+        public void Result_Failure_WithDefaultMessage_ReturnsResultWithDefaultMessage()
+        {
+            var result = Result.Failure(ErrorType.BadRequest);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)ErrorType.BadRequest, result.StatusCode);
+            Assert.IsNotNull(result.Messages);
+            Assert.IsTrue(result.Messages.Any());
+            // Assuming HttpError.GetError(ErrorType.BadRequest).Messages contains known message(s)
+            // This part depends on the actual default message for BadRequest
+            Assert.AreEqual("Your request could not be understood due to malformed syntax.", result.Messages.First());
+        }
+
+        [Test]
+        public void Result_Failure_WithCustomMessage_ReturnsResultWithCustomMessage()
+        {
+            var customMessages = new List<string> { "Custom error message" };
+            var result = Result.Failure(ErrorType.BadRequest, customMessages);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)ErrorType.BadRequest, result.StatusCode);
+            Assert.AreEqual(customMessages, result.Messages);
+        }
+
+        // Tests for Result.Success
+        [Test]
+        public void Result_Success_WithDefaultMessage_ReturnsResultWithDefaultMessage()
+        {
+            var result = Result.Success(SuccessType.Ok);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)SuccessType.Ok, result.StatusCode);
+            Assert.IsNotNull(result.Messages);
+            Assert.IsTrue(result.Messages.Any());
+            Assert.AreEqual("The request has succeeded.", result.Messages.First());
+        }
+
+        [Test]
+        public void Result_Success_WithCustomMessage_ReturnsResultWithCustomMessage()
+        {
+            var customMessages = new List<string> { "Custom success message" };
+            var result = Result.Success(SuccessType.Ok, customMessages);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)SuccessType.Ok, result.StatusCode);
+            Assert.AreEqual(customMessages, result.Messages);
+        }
+
+        // Tests for Result<TData>.Failure
+        [Test]
+        public void ResultTData_Failure_WithDefaultMessage_ReturnsResultWithDefaultMessageAndNullData()
+        {
+            var result = Result<string>.Failure(ErrorType.NotFound);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)ErrorType.NotFound, result.StatusCode);
+            Assert.IsNull(result.Data);
+            Assert.IsNotNull(result.Messages);
+            Assert.IsTrue(result.Messages.Any());
+            Assert.AreEqual("The requested resource could not be found.", result.Messages.First());
+        }
+
+        [Test]
+        public void ResultTData_Failure_WithCustomMessage_ReturnsResultWithCustomMessageAndNullData()
+        {
+            var customMessages = new List<string> { "Custom not found" };
+            var result = Result<string>.Failure(ErrorType.NotFound, customMessages);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)ErrorType.NotFound, result.StatusCode);
+            Assert.IsNull(result.Data);
+            Assert.AreEqual(customMessages, result.Messages);
+        }
+
+        // Tests for Result<TData>.Success
+        [Test]
+        public void ResultTData_Success_WithDefaultMessageAndData_ReturnsResultWithDefaultMessageAndData()
+        {
+            var data = "Test Data";
+            var result = Result<string>.Success(SuccessType.Ok, data);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)SuccessType.Ok, result.StatusCode);
+            Assert.AreEqual(data, result.Data);
+            Assert.IsNotNull(result.Messages);
+            Assert.IsTrue(result.Messages.Any());
+            Assert.AreEqual("The request has succeeded.", result.Messages.First());
+        }
+
+        [Test]
+        public void ResultTData_Success_WithCustomMessageAndData_ReturnsResultWithCustomMessageAndData()
+        {
+            var data = "Test Data";
+            var customMessages = new List<string> { "Custom OK" };
+            var result = Result<string>.Success(SuccessType.Ok, data, customMessages);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)SuccessType.Ok, result.StatusCode);
+            Assert.AreEqual(data, result.Data);
+            Assert.AreEqual(customMessages, result.Messages);
+        }
+
+        // Test for IsSuccess property
+        [Test]
+        public void Result_IsSuccess_TrueForSuccessCodes()
+        {
+            var result = Result.Success(SuccessType.Ok);
+            Assert.IsTrue(result.IsSuccess);
+        }
+
+        [Test]
+        public void Result_IsSuccess_FalseForErrorCodes()
+        {
+            var result = Result.Failure(ErrorType.BadRequest);
+            Assert.IsFalse(result.IsSuccess);
+        }
+
+        [Test]
+        public void Result_IsSuccess_FalseForRedirectCodes()
+        {
+            var result = Result.Redirect(RedirectType.MovedPermanently);
+            Assert.IsFalse(result.IsSuccess); // Assuming redirects are not "IsSuccess"
+        }
+
+        [Test]
+        public void Result_IsSuccess_FalseForInformativeCodes()
+        {
+            var result = Result.Informative(InformativeType.Continue);
+            Assert.IsFalse(result.IsSuccess); // Assuming informative are not "IsSuccess"
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces several improvements to the DevSource.Stack.Results library based on a detailed analysis:

- **Enhanced Robustness:**
    - Factory methods (Result.Success, Result.Failure, etc.) now throw an InvalidOperationException if default messages are not configured for a status type, instead of returning null.
    - ResultPaged<TData>.TotalPages calculation is fixed to prevent NullReferenceException and DivideByZeroException.
    - ResultPaged<TData> constructor now correctly preserves null for NextPage/PreviousPage properties.

- **Improved Design & SOLID Adherence:**
    - Introduced provider interfaces (IHttpErrorProvider, etc.) and status object interfaces (IErrorStatus, etc.) to decouple Result classes from concrete static implementations, significantly improving Dependency Inversion.
    - Standardized message handling in factory methods to use all defined default messages.
    - Ensured consistency in HttpSuccess.Messages property (non-nullable).

- **Added Unit Tests:**
    - New test files (ResultTests.cs, ResultPagedTests.cs) with tests for TotalPages, message handling, NextPage/PreviousPage nullability, and IsSuccess property.

These changes make the library more robust, maintainable, extensible, and better aligned with SOLID principles.